### PR TITLE
Fix some typo changes in code

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,7 +23,7 @@ public class Messages {
     public static final String MESSAGE_NOT_VIEWING_PATIENT_LIST = "Command only works when displaying patients.\n"
             + "Use the following command first: list";
     public static final String MESSAGE_NOT_VIEWING_APPOINTMENT = "Command only works when displaying appointments.\n"
-            + "Use the following command first: list-appt";
+            + "Use the following command first: list-appt [INDEX]";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditAppointmentCommand.java
@@ -5,8 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.Messages.MESSAGE_NOT_VIEWING_APPOINTMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_TITLE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -33,8 +31,7 @@ public class EditAppointmentCommand extends Command {
             + "[" + PREFIX_APPOINTMENT_TITLE + "TITLE] "
             + "[" + PREFIX_APPOINTMENT_DATETIME + "DATE_TIME (dd-MM-yyyy, HHmm)]\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_NRIC + "S1234567A "
-            + PREFIX_INDEX + "1 "
+            + "1 "
             + PREFIX_APPOINTMENT_TITLE + "Dental Checkup "
             + PREFIX_APPOINTMENT_DATETIME + "10-10-2010, 0900\n";
 

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
@@ -24,7 +24,7 @@ public class ListAppointmentCommand extends Command {
     public static final String COMMAND_WORD = "list-appt";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": List appointments of a patient identified by the index number used in the displayed patient list.\n."
+            + ": List appointments of a patient identified by the index number used in the displayed patient list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -15,7 +15,7 @@ import java.util.Objects;
 public class Appointment implements Comparable<Appointment> {
     public static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern("dd-MM-uuuu, HHmm");
     public static final String DATETIME_MESSAGE_CONSTRAINTS =
-            "Appointment date invalid! Expected Format: dd-MM-yyyy, HHmm";
+            "Appointment date invalid! Either invalid timing, or not following expected Format: dd-MM-yyyy, HHmm";
 
     private final Title title;
     private final LocalDateTime dateTime;

--- a/src/main/java/seedu/address/model/medicalhistory/MedicalHistory.java
+++ b/src/main/java/seedu/address/model/medicalhistory/MedicalHistory.java
@@ -10,7 +10,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class MedicalHistory {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Tag names should be alphanumeric and may contain hyphens or spaces";
+            "MedicalHistory titles should be alphanumeric and may contain hyphens or spaces.\n"
+            + "eg. mh/covid-19";
     public static final String VALIDATION_REGEX = "[\\p{Alnum}- ]+";
 
     public final String tagName;


### PR DESCRIPTION
* Better appointment datetime error message (Fixes #218 and #243 )
* Not viewing appointment list better error message (Fixes #214 )
* Update edit-appt error message example (Fixes #257 )
* MedicalHistory still called Tag in error message (Fixes #254 )
* list-appt error message typo (Fixes #248 )
* Give example medicalhistory (Fixes #238 )